### PR TITLE
Add -N or --no-default-middleware option.

### DIFF
--- a/bin/zbatery
+++ b/bin/zbatery
@@ -59,6 +59,11 @@ opts = OptionParser.new("", 24, '  ') do |opts|
     ENV["RACK_ENV"] = e
   end
 
+  opts.on("-N", "--no-default-middleware",
+          "do not load middleware implied by RACK_ENV") do |e|
+    rackup_opts[:no_default_middleware] = true
+  end
+
   opts.on("-D", "--daemonize", "run daemonized in the background") do |d|
     rackup_opts[:daemonize] = !!d
   end


### PR DESCRIPTION
This would prevent Unicorn (Zbatery) from adding default middleware,
as if RACK_ENV were always none. (not development nor deployment)

This is implemented in Unicorn, so we only need to update
the option parser here.

Discussion thread on Unicorn mailing list:
http://rubyforge.org/pipermail/mongrel-unicorn/2013-January/001675.html
